### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ fast_app = js.get_app()
 
 js.custom_openapi(
     app=fast_app,
+    logo_url="https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg",
     title="AkenoX Beta AI API",
     version="1.0.0",
     summary="Use It Only For Personal Projects",
@@ -168,6 +169,7 @@ async def send_message(text: str, chat_id: str):
 
 js.custom_openapi(
     app=fast_app,
+    logo_url="https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg",
     title="AkenoX Beta AI API",
     version="1.0.0",
     summary="Use It Only For Personal Project",

--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -56,7 +56,9 @@ class AkenoXJs:
     def get_custom_openai(self, **args):
         return self.custom_openai(**args)
 
-    def custom_openapi(self, app, logo_url: str = "https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg", **args):
+    def custom_openapi(self, app=None, logo_url: str = "https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg", **args):
+        if not app:
+            raise ValueError("Required app")
         if app.openapi_schema:
             return app.openapi_schema
         openapi_schema = self.get_custom_openai(**args)

--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -56,13 +56,11 @@ class AkenoXJs:
     def get_custom_openai(self, **args):
         return self.custom_openai(**args)
 
-    def custom_openapi(self, app, **args):
+    def custom_openapi(self, app, logo_url: str = "https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg", **args):
         if app.openapi_schema:
             return app.openapi_schema
         openapi_schema = self.get_custom_openai(**args)
-        openapi_schema["info"]["x-logo"] = {
-            "url": "https://github-production-user-asset-6210df.s3.amazonaws.com/90479255/289277800-f26513f7-cdf4-44ee-9a08-f6b27e6b99f7.jpg"
-        }
+        openapi_schema["info"]["x-logo"] = {"url": url}
         app.openapi_schema = openapi_schema
         return app.openapi_schema
 

--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -62,7 +62,7 @@ class AkenoXJs:
         if app.openapi_schema:
             return app.openapi_schema
         openapi_schema = self.get_custom_openai(**args)
-        openapi_schema["info"]["x-logo"] = {"url": url}
+        openapi_schema["info"]["x-logo"] = {"url": logo_url}
         app.openapi_schema = openapi_schema
         return app.openapi_schema
 


### PR DESCRIPTION
## Summary by Sourcery

Add a `logo_url` parameter to the `custom_openapi` function to allow setting a custom logo URL for the OpenAPI schema. Make the `app` argument of the `custom_openapi` function required.

Enhancements:
- Add `logo_url` as a parameter to the `custom_openapi` function
- Make the `app` argument required in the `custom_openapi` function

Documentation:
- Update the README to reflect the changes in the API, including the new logo URL parameter