### PR TITLE
_

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ print(response)
 - `api_key:` (Optional) API key for authentication.
 - `post:` Boolean flag to indicate POST requests.
 - `is_obj:` Boolean flag indicating whether the response should be returned as a Python object (True) or in the default format (False).
-- `custom_dev_fast:` Boolean flag default return None
+- `custom_dev_fast:` Boolean flag defaults to None
 - `**kwargs:` to object pass like JSON
 
 ```py

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ print(response)
 - `post:` Boolean flag to indicate POST requests.
 - `is_obj:` Boolean flag indicating whether the response should be returned as a Python object (True) or in the default format (False).
 - `custom_dev_fast:` Boolean flag defaults to None
-- `**kwargs:` to object pass like JSON
+- `**kwargs:` Allows passing additional parameters as a dictionary, which will be sent as JSON.
 
 ```py
 randydev(endpoint, api_key=None, post=False, is_obj=False, custom_dev_fast=False, **params)

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ print(response)
 - `api_key:` (Optional) API key for authentication.
 - `post:` Boolean flag to indicate POST requests.
 - `is_obj:` Boolean flag indicating whether the response should be returned as a Python object (True) or in the default format (False).
+- `custom_dev_fast:` Boolean flag default return None
+- `**kwargs:` to object pass like JSON
 
 ```py
 randydev(endpoint, api_key=None, post=False, is_obj=False, custom_dev_fast=False, **params)


### PR DESCRIPTION
## Summary by Sourcery

Add `custom_dev_fast` parameter and `**kwargs` to the `randydev` function. Document these new additions in the README.

Enhancements:
- Added `custom_dev_fast` parameter to the `randydev` function, defaulting to `False`.
- Added `**kwargs` to the `randydev` function to allow passing additional parameters as a JSON object or Python dictionary

Documentation:
- Added documentation for the new `custom_dev_fast` parameter and `**kwargs` in the `randydev` function in the README.md file