### PR TITLE
_

### DIFF
--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -175,7 +175,7 @@ class AkenoXJs:
     def _get_public_url(self, is_allow_use=False):
         return self.public_url if is_allow_use else ""
 
-    @fast.log_performance
+    @fast.no_async_log_performance
     def no_async_randydev(
         self,
         endpoint,

--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -175,7 +175,6 @@ class AkenoXJs:
     def _get_public_url(self, is_allow_use=False):
         return self.public_url if is_allow_use else ""
 
-    @_handle_request_errors
     @fast.log_performance
     def no_async_randydev(
         self,

--- a/akenoai/logger.py
+++ b/akenoai/logger.py
@@ -20,3 +20,13 @@ def log_performance(func):
         LOGS.info(f"Execution time for {func.__name__}: {end_time - start_time:.2f} seconds")
         return result
     return wrapper
+
+def no_async_log_performance(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        LOGS.info(f"Execution time for {func.__name__}: {end_time - start_time:.2f} seconds")
+        return result
+    return wrapper


### PR DESCRIPTION
## Summary by Sourcery

Introduce a synchronous performance logging decorator and update the `no_async_randydev` method to use it.

Enhancements:
- Introduce a synchronous version of the `log_performance` decorator, called `no_async_log_performance`.
- Use the new `no_async_log_performance` decorator for the `no_async_randydev` method, replacing the asynchronous version and the `_handle_request_errors` decorator