### PR TITLE
_

### DIFF
--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -60,7 +60,6 @@ class AkenoXJs:
         self.obj = Box
         self.request_in = aiohttp
         self._json = json
-        self._uvloop = uvloop
 
     def fasthttp(self):
         return self.request_in
@@ -74,8 +73,8 @@ class AkenoXJs:
     def rjson_dumps(self, obj, indent=4, **args):
         return self._json.dumps(obj, indent=indent, **args)
 
-    def ultra_fast_uvloop_install(self):
-        self._uvloop.install()
+    def install_ultra_fast_asyncio(self):
+        uvloop.install()
 
     def get_custom_openai(self, **args):
         return self.custom_openai(**args)


### PR DESCRIPTION
## Summary by Sourcery

This pull request updates the uvloop installation method to use the standard `uvloop.install()` function, and removes the `_uvloop` attribute from the class.

Enhancements:
- Replaced the custom uvloop installation method with a standard installation using `uvloop.install()`.

Chores:
- Removed the `_uvloop` attribute from the class.