### PR TITLE
_

### DIFF
--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -445,11 +445,11 @@ class AkenoXDev:
         if image_content:
             return self._perform_request(url, params, return_json=False)
 
-        responses_contet = self._perform_request(url, params, return_json=False)
+        responses_content = self._perform_request(url, params, return_json=False)
         with open(filename, "wb") as f:
-            f.write(responses_contet)
+            f.write(responses_content)
         LOGS.info(f"Successfully save check: {filename}")
-        return responses_contet
+        return filename
 
     def anime_hentai(self, view_url=False):
         ok, status_or_response = self._check_connection()


### PR DESCRIPTION
## Summary by Sourcery

Fixes a typo in the `flux_schnell` method where `responses_contet` was misspelled. Also, the method now returns the filename instead of the image content.

Bug Fixes:
- Fixes a typo in the `flux_schnell` method where `responses_contet` was misspelled.
- The `flux_schnell` method now returns the filename instead of the image content.