### PR TITLE
_

### DIFF
--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -338,6 +338,11 @@ class RandyDev(BaseDev):
                 f.write(base64.b64decode(response.download))
             return filename
 
+class ControlDev(RandyDev):
+    def __init__(self):
+        self.is_bypass_control = True
+        super().__init__()
+
 class AkenoXJs:
     def __init__(self, is_err: bool = False, is_itzpire: bool = False, is_akenox_fast: bool = False):
         """
@@ -351,7 +356,7 @@ class AkenoXJs:
             "itzpire": ItzPire(),
             "err": ErAPI(),
             "akenox_fast": AkenoXDevFaster(),
-            "default": RandyDev()
+            "default": ControlDev()
         }
         self.flags = {
             "itzpire": is_itzpire,


### PR DESCRIPTION
## Summary by Sourcery

Modify the default development mode in AkenoXJs to use a new ControlDev class with bypass control enabled

Enhancements:
- Introduce a new ControlDev class that inherits from RandyDev with a predefined is_bypass_control flag set to True

Chores:
- Replace the default development mode from RandyDev to ControlDev in the AkenoXJs initialization