### PR TITLE
_

### DIFF
--- a/akenoai/akeno.py
+++ b/akenoai/akeno.py
@@ -192,6 +192,7 @@ class GenericEndpoint:
         self,
         parent: BaseDev,
         endpoint: str,
+        post: bool = False,
         super_fast: bool = False
     ):
         self.parent = parent
@@ -202,7 +203,7 @@ class GenericEndpoint:
     async def create(self, ctx: str = None, is_obj: bool = False, **kwargs):
         if not ctx:
             raise ValueError("ctx name is required.")
-        response = await self.parent._make_request("get", f"{self.endpoint}/{ctx}", **kwargs) or {}
+        response = await self.parent._make_request("post", f"{self.endpoint}/{ctx}", **kwargs) or {} if post else await self.parent._make_request("get", f"{self.endpoint}/{ctx}", **kwargs) or {}
         _response_parent = self.parent.obj(response) if is_obj else response
         return _response_parent if self.super_fast else None
 
@@ -272,7 +273,7 @@ class RandyDev(BaseDev):
         self.is_bypass_control = is_bypass_control
         self.update_public_url()
         super().__init__(self.public_url)
-        self.chat = GenericEndpoint(self, "fast", super_fast=True) if self.is_bypass_control else GenericEndpoint(self, "ai", super_fast=True)
+        self.chat = GenericEndpoint(self, "fast", post=True, super_fast=True) if self.is_bypass_control else GenericEndpoint(self, "ai", super_fast=True)
         self.downloader = GenericEndpoint(self, "fast", super_fast=True) if self.is_bypass_control else GenericEndpoint(self, "dl", super_fast=True)
         self.image = GenImageEndpoint(self, "flux", super_fast=True)
         self.user = self.User(self)


### PR DESCRIPTION
## Summary by Sourcery

Add support for POST requests in GenericEndpoint and modify chat endpoint initialization to use POST method for bypass control

Enhancements:
- Introduced a new 'post' parameter to GenericEndpoint to allow switching between GET and POST request methods
- Modified the create method to conditionally use POST or GET requests based on the 'post' parameter